### PR TITLE
update

### DIFF
--- a/packages/core/classes/Window.ts
+++ b/packages/core/classes/Window.ts
@@ -96,7 +96,7 @@ export default class Window implements WindowTemplate {
     }
 
     this.options = Object.assign(this.options, options);
-    this.layout = Object.assign(this.layout, layout);
+    this.setLayout({ ...this.layout, ...layout });
   }
 
   setLayout(layout: Partial<WindowLayout>) {

--- a/packages/core/classes/WindowWrapper.ts
+++ b/packages/core/classes/WindowWrapper.ts
@@ -207,11 +207,10 @@ export default class WindowWrapper {
       windowModel = this.get(model);
     }
     if (windowModel) {
-      windowModel.layout.position = ipoint(0, 0);
-      windowModel.layout.size = ipoint(
-        this.parentLayout.size.x,
-        this.parentLayout.size.y
-      );
+      windowModel.setLayout({
+        position: ipoint(0, 0),
+        size: ipoint(this.layout.size.x, this.layout.size.y)
+      });
     }
   }
 
@@ -304,17 +303,21 @@ export default class WindowWrapper {
 }
 
 function fullWindow(window: Window, layout: Layout) {
-  window.layout.position = ipoint(0, 0);
-  window.layout.size = ipoint(layout.size.x, layout.size.y);
+  window.setLayout({
+    position: ipoint(0, 0),
+    size: ipoint(layout.size.x, layout.size.y)
+  });
 }
 
 function centerWindow(window: Window, layout: Layout) {
-  window.layout.position = ipoint(
-    () =>
-      (ipoint(layout.size.x, layout.size.y) -
-        ipoint(window.layout.size.x, window.layout.size.y)) /
-      2
-  );
+  window.setLayout({
+    position: ipoint(
+      () =>
+        (ipoint(layout.size.x, layout.size.y) -
+          ipoint(window.layout.size.x, window.layout.size.y)) /
+        2
+    )
+  });
 }
 
 function windowPositionDiagonal(
@@ -336,7 +339,9 @@ function windowPositionDiagonal(
         ipoint(layout.size.x, layout.size.y) -
         ipoint(window.layout.size.x, window.layout.size.y)
     );
-    window.layout.position = ipoint(() => Math.max(Math.min(position, min), 0));
+    window.setLayout({
+      position: ipoint(() => Math.max(Math.min(position, min), 0))
+    });
   });
 }
 
@@ -350,14 +355,18 @@ function windowPositionSplit(
   if (vertical) {
     position = ipoint(layout.size.x, layout.size.y / length);
     windows.forEach((window, i) => {
-      window.layout.position = ipoint(0, i * position.y);
-      window.layout.size = position;
+      window.setLayout({
+        position: ipoint(0, i * position.y),
+        size: position
+      });
     });
   } else {
     position = ipoint(layout.size.x / length, layout.size.y);
     windows.forEach((window, i) => {
-      window.layout.position = ipoint(i * position.x, 0);
-      window.layout.size = position;
+      window.setLayout({
+        position: ipoint(i * position.x, 0),
+        size: position
+      });
     });
   }
 }

--- a/packages/core/components/Core.vue
+++ b/packages/core/components/Core.vue
@@ -233,6 +233,13 @@ const headerVisible = computed(() => {
   return true;
 });
 
+watch(
+  () => headerVisible.value,
+  () => {
+    windowWrapperEl.value?.refresh();
+  }
+);
+
 const headerAbsolute = computed(() => {
   if ($props.core.modules.windows) {
     return $props.core.modules.windows.contentWrapper.isHeaderAbsolute();

--- a/packages/core/components/Core.vue
+++ b/packages/core/components/Core.vue
@@ -233,19 +233,25 @@ const headerVisible = computed(() => {
   return true;
 });
 
-watch(
-  () => headerVisible.value,
-  () => {
-    windowWrapperEl.value?.refresh();
-  }
-);
-
 const headerAbsolute = computed(() => {
   if ($props.core.modules.windows) {
     return $props.core.modules.windows.contentWrapper.isHeaderAbsolute();
   }
   return false;
 });
+
+watch(
+  () => headerVisible.value,
+  () => {
+    windowWrapperEl.value?.refresh();
+  }
+);
+watch(
+  () => headerAbsolute.value,
+  () => {
+    windowWrapperEl.value?.refresh();
+  }
+);
 
 const screenBootSequence = computed(() => {
   if (currentError.value) {

--- a/packages/core/components/Window.vue
+++ b/packages/core/components/Window.vue
@@ -175,7 +175,7 @@ const rootHeaderHeight = ref(
 );
 const layoutSizeOffset = computed(() =>
   ipoint(
-    4,
+    $props.window.options.borderless ? 0 : 4,
     $props.window.options.embed
       ? 0
       : rootHeaderHeight.value + WINDOW_BORDER_SIZE

--- a/packages/core/components/Window.vue
+++ b/packages/core/components/Window.vue
@@ -302,13 +302,8 @@ const styleClasses = computed(() => {
   };
 });
 
-const wrapperSize = computed(() => {
-  return wrapperLayout.value.size;
-});
-
-const layout = computed(() => {
-  return $props.window.layout;
-});
+const wrapperSize = computed(() => wrapperLayout.value.size);
+const layout = computed(() => $props.window.layout);
 
 const size = computed(() => {
   return layout.value.size;

--- a/packages/core/components/WindowWrapper.vue
+++ b/packages/core/components/WindowWrapper.vue
@@ -136,10 +136,8 @@ const refresh = (force: boolean = false) => {
   }
   return new Promise(resolve => {
     nextTick(() => {
-      window.setTimeout(() => {
-        onRefresh();
-        resolve(undefined);
-      }, 500);
+      onRefresh();
+      resolve(undefined);
     });
   });
 };

--- a/packages/disk-extras13/boing/components/App.vue
+++ b/packages/disk-extras13/boing/components/App.vue
@@ -12,9 +12,13 @@ import { EMIT_TYPE, setupScene, type SceneOptions } from '../main';
 import useAudioControl from '../composables/useAudioControl';
 import { SFX } from '../utils/sounds';
 import type { RendererOptions } from '../types';
+import { Vector2 } from 'three';
 
 const rendererEl = ref<InstanceType<typeof Renderer> | null>(null);
 const subscription = new Subscription();
+
+const dimension = ref<Vector2>();
+let resizeObserver: ResizeObserver;
 
 const { playSfx, setGlobalVolume } = useAudioControl();
 const $props = defineProps<{
@@ -57,9 +61,21 @@ onMounted(() => {
         playSfx(SFX.WALL_1);
       })
   );
+
+  const onResize = () => {
+    dimension.value = new Vector2(
+      rendererEl.value.$el.value.offsetWidth,
+      rendererEl.value.$el.value.offsetHeight
+    );
+    rendererEl.value.renderer.resize(dimension.value);
+  };
+  resizeObserver = new ResizeObserver(onResize);
+
+  resizeObserver.observe(rendererEl.value.$el);
 });
 
 onUnmounted(() => {
+  resizeObserver.disconnect();
   subscription.unsubscribe();
 });
 </script>

--- a/packages/disk-extras13/boing/components/Renderer.vue
+++ b/packages/disk-extras13/boing/components/Renderer.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script lang="ts" setup>
-import { provide, ref, onUnmounted, onMounted } from 'vue';
+import { provide, ref, onUnmounted, onMounted, nextTick } from 'vue';
 import Renderer from '../classes/Renderer';
 import { Vector2 } from 'three';
 import type { RendererOptions } from '../types';
@@ -24,9 +24,6 @@ const $emit = defineEmits(['ready']);
 
 const rootEl = ref();
 const canvasEl = ref();
-const dimension = ref<Vector2>();
-
-let resizeObserver: ResizeObserver;
 
 const defaultRendererOptions: RendererOptions = {
   pixelSize: 3,
@@ -35,34 +32,25 @@ const defaultRendererOptions: RendererOptions = {
 };
 
 onMounted(async () => {
-  dimension.value = new Vector2(
+  const dimension = new Vector2(
     rootEl.value.offsetWidth,
     rootEl.value.offsetHeight
   );
   const { pixelSize, controls, debugGui } =
     $props.options || defaultRendererOptions;
 
-  renderer.value = new Renderer(canvasEl.value, dimension.value, {
+  renderer.value = new Renderer(canvasEl.value, dimension, {
     pixelSize: pixelSize,
     controls: controls,
     debugGui: debugGui
   });
 
-  resizeObserver = new ResizeObserver(() => {
-    dimension.value = new Vector2(
-      rootEl.value.offsetWidth,
-      rootEl.value.offsetHeight
-    );
-    renderer.value.resize(dimension.value);
+  nextTick(() => {
+    $emit('ready');
   });
-
-  resizeObserver.observe(rootEl.value);
-
-  $emit('ready');
 });
 
 onUnmounted(() => {
-  resizeObserver.disconnect();
   renderer.value.destroy();
 });
 

--- a/packages/disk-workbench13/screenDiagnose/components/App.vue
+++ b/packages/disk-workbench13/screenDiagnose/components/App.vue
@@ -70,11 +70,19 @@ const $props = defineProps<{
 
 const currentTest = ref(availableTests[0]);
 
-const { parentLayout } = useWindow();
-
 const rootEl = ref<HTMLInputElement | null>(null);
 const canvasEl = ref<HTMLCanvasElement | null>(null);
 const subscription = new Subscription();
+
+const { parentLayout } = useWindow();
+
+watch(
+  () => parentLayout.value.size,
+  () => {
+    render();
+  },
+  { deep: true }
+);
 
 onMounted(async () => {
   const canvas = canvasEl.value;


### PR DESCRIPTION
This pull request refactors how window layout updates are handled throughout the core window management system. The main improvement is the consistent use of the `setLayout` method for updating window layouts, which helps encapsulate layout changes and ensures any related side effects are properly triggered. Additionally, the changes introduce some UI reactivity improvements and minor code cleanups.

**Refactoring window layout updates:**
* Replaced direct assignments to `window.layout` with calls to the `setLayout` method in `Window`, ensuring all layout changes go through a single, controlled entry point (`packages/core/classes/Window.ts`, `packages/core/classes/WindowWrapper.ts`). [[1]](diffhunk://#diff-30cea5e4d0035c4914ebf4e30a54eab65646710753663a3ac89dedd00ac4bf04L99-R99) [[2]](diffhunk://#diff-d0da0d9f043b80c308ab435dd8e442de7fd84125d47c01ba89bdce94d4a901eeL210-R213) [[3]](diffhunk://#diff-d0da0d9f043b80c308ab435dd8e442de7fd84125d47c01ba89bdce94d4a901eeL307-R320) [[4]](diffhunk://#diff-d0da0d9f043b80c308ab435dd8e442de7fd84125d47c01ba89bdce94d4a901eeL339-R344) [[5]](diffhunk://#diff-d0da0d9f043b80c308ab435dd8e442de7fd84125d47c01ba89bdce94d4a901eeL353-R369)

**UI reactivity improvements:**
* Added a watcher on `headerVisible` in `Core.vue` to trigger a refresh of the window wrapper when the header visibility changes, ensuring the UI stays in sync (`packages/core/components/Core.vue`).
* Added a watcher on `parentLayout.size` in the disk workbench app to re-render the component when the parent layout changes, improving responsiveness to layout updates (`packages/disk-workbench13/screenDiagnose/components/App.vue`).

**Code cleanup and simplification:**
* Simplified computed property definitions in `Window.vue` for `wrapperSize` and `layout` for better readability (`packages/core/components/Window.vue`).
* Removed unnecessary `setTimeout` from the `refresh` method in `WindowWrapper.vue` to streamline refresh logic (`packages/core/components/WindowWrapper.vue`).